### PR TITLE
Fix for "tr-pass handling

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -697,12 +697,6 @@ HttpSM::state_read_client_request_header(int event, void *data)
     // blind tunnel
     if ((event == VC_EVENT_READ_READY || event == VC_EVENT_EOS) && state == PARSE_RESULT_ERROR) {
       do_blind_tunnel = true;
-
-      // If we had a GET request that has data after the
-      // get request, do blind tunnel
-    } else if (state == PARSE_RESULT_DONE && t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_GET &&
-               ua_buffer_reader->read_avail() > 0 && !t_state.hdr_info.client_request.is_keep_alive_set()) {
-      do_blind_tunnel = true;
     }
     if (do_blind_tunnel) {
       DebugSM("http", "[%" PRId64 "] first request on connection failed parsing, switching to passthrough.", sm_id);


### PR DESCRIPTION
Fix for https://github.com/apache/trafficserver/commit/497e4755d7773590204b89b6c262f6605a9c8e21
I commented there:

These lines will cause each request to fall to passthrough bypass:

```
+    // If we had a GET request that has data after the
 +    // get request, do blind tunnel
 +    } else if (state == PARSE_DONE &&
 +               t_state.hdr_info.client_request.method_get_wksidx() == 
 +               HTTP_WKSIDX_GET &&
 +               ua_raw_buffer_reader->read_avail() > 0 &&
 +               !t_state.hdr_info.client_request.is_keep_alive_set()) {
 +      do_blind_tunnel = true;
 +    }
```
This is because ua_raw_buffer_reader->read_avail() always will be grater than zero.
You haven't see it until now because of another bug (#1448) that cause is_transparent_passthrough_allowed() to be always false and this for it never reached to your lines.
This is why I suggest to just delete them meantime.