### PR TITLE
Revert "is_transparent_passthrough_allowed always returns false"

### DIFF
--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -174,12 +174,6 @@ public:
     return "http";
   }
 
-  virtual bool
-  is_transparent_passthrough_allowed() const
-  {
-    return f_transparent_passthrough;
-  }
-  
 private:
   Http1ClientSession(Http1ClientSession &);
 


### PR DESCRIPTION
Reverts ykopel/trafficserver#3